### PR TITLE
Fixed error when --no_wandb is specified

### DIFF
--- a/src/models/train.py
+++ b/src/models/train.py
@@ -207,7 +207,7 @@ class CLI(LightningCLI):
         else:
             results = self.trainer.logged_metrics
 
-        if results:
+        if results and self.trainer.logger is not None:
             self.trainer.logger.log_metrics(results)
 
     def set_defaults(self):

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -4,6 +4,7 @@ import logging
 from operator import mul
 from statistics import mode
 from typing import Optional, Any
+from pprint import pprint
 
 import warnings
 import os
@@ -207,8 +208,11 @@ class CLI(LightningCLI):
         else:
             results = self.trainer.logged_metrics
 
-        if results and self.trainer.logger is not None:
-            self.trainer.logger.log_metrics(results)
+        if results:
+            if self.trainer.logger is not None:
+                self.trainer.logger.log_metrics(results)
+            else:
+                pprint(results)
 
     def set_defaults(self):
         ...


### PR DESCRIPTION
When the --no_wandb flag is specified, the trainer.logger is None and therefore cannot log the resulting metrics.